### PR TITLE
add jenkins connection limit

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -44,6 +44,7 @@ type JenkinsConfig struct {
 	Address  string `default:"http://jenkins.kubesphere.com/"`
 	User     string `default:"magicsong"`
 	Password string `default:"devops"`
+	MaxConn  string `default:"20"`
 }
 
 func (m *MysqlConfig) GetUrl() string {

--- a/pkg/ds/ds.go
+++ b/pkg/ds/ds.go
@@ -14,6 +14,8 @@ limitations under the License.
 package ds
 
 import (
+	"strconv"
+
 	"kubesphere.io/devops/pkg/config"
 	"kubesphere.io/devops/pkg/constants"
 	"kubesphere.io/devops/pkg/db"
@@ -45,8 +47,12 @@ func (p *Ds) openDatabase() *Ds {
 }
 
 func (p *Ds) connectJenkins() {
-	jenkins := gojenkins.CreateJenkins(nil, p.cfg.Jenkins.Address, p.cfg.Jenkins.User, p.cfg.Jenkins.Password)
-	jenkins, err := jenkins.Init()
+	maxConnection, err := strconv.Atoi(p.cfg.Jenkins.MaxConn)
+	if err != nil {
+		panic(err)
+	}
+	jenkins := gojenkins.CreateJenkins(nil, p.cfg.Jenkins.Address, maxConnection, p.cfg.Jenkins.User, p.cfg.Jenkins.Password)
+	jenkins, err = jenkins.Init()
 	if err != nil {
 		logger.Critical("failed to connect jenkins")
 		panic(err)

--- a/pkg/gojenkins/jenkins.go
+++ b/pkg/gojenkins/jenkins.go
@@ -1026,13 +1026,13 @@ func (j *Jenkins) GetQueueItem(number int64) (*QueueItemResponse, error) {
 // Creates a new Jenkins Instance
 // Optional parameters are: client, username, password
 // After creating an instance call init method.
-func CreateJenkins(client *http.Client, base string, auth ...interface{}) *Jenkins {
+func CreateJenkins(client *http.Client, base string, maxConnection int, auth ...interface{}) *Jenkins {
 	j := &Jenkins{}
 	if strings.HasSuffix(base, "/") {
 		base = base[:len(base)-1]
 	}
 	j.Server = base
-	j.Requester = &Requester{Base: base, SslVerify: true, Client: client}
+	j.Requester = &Requester{Base: base, SslVerify: true, Client: client, connControl: make(chan struct{}, maxConnection)}
 	if j.Requester.Client == nil {
 		j.Requester.Client = http.DefaultClient
 	}

--- a/pkg/gojenkins/request.go
+++ b/pkg/gojenkins/request.go
@@ -52,11 +52,12 @@ func NewAPIRequest(method string, endpoint string, payload io.Reader) *APIReques
 }
 
 type Requester struct {
-	Base      string
-	BasicAuth *BasicAuth
-	Client    *http.Client
-	CACert    []byte
-	SslVerify bool
+	Base        string
+	BasicAuth   *BasicAuth
+	Client      *http.Client
+	CACert      []byte
+	SslVerify   bool
+	connControl chan struct{}
 }
 
 func (r *Requester) SetCrumb(ar *APIRequest) error {
@@ -180,7 +181,6 @@ func (r *Requester) Do(ar *APIRequest, responseStruct interface{}, options ...in
 		}
 	}
 	var req *http.Request
-
 	if fileUpload {
 		body := &bytes.Buffer{}
 		writer := multipart.NewWriter(body)
@@ -226,13 +226,17 @@ func (r *Requester) Do(ar *APIRequest, responseStruct interface{}, options ...in
 	if r.BasicAuth != nil {
 		req.SetBasicAuth(r.BasicAuth.Username, r.BasicAuth.Password)
 	}
+	req.Close = true
 	req.Header.Add("Accept", "*")
 	for k := range ar.Headers {
 		req.Header.Add(k, ar.Headers.Get(k))
 	}
+	r.connControl <- struct{}{}
 	if response, err := r.Client.Do(req); err != nil {
+		<-r.connControl
 		return nil, err
 	} else {
+		<-r.connControl
 		errorText := response.Header.Get("X-Error")
 		if errorText != "" {
 			return nil, errors.New(errorText)
@@ -270,9 +274,12 @@ func (r *Requester) DoPostForm(ar *APIRequest, responseStruct interface{}, form 
 	for k := range ar.Headers {
 		req.Header.Add(k, ar.Headers.Get(k))
 	}
+	r.connControl <- struct{}{}
 	if response, err := r.Client.Do(req); err != nil {
+		<-r.connControl
 		return nil, err
 	} else {
+		<-r.connControl
 		errorText := response.Header.Get("X-Error")
 		if errorText != "" {
 			return nil, errors.New(errorText)

--- a/pkg/gojenkins/request.go
+++ b/pkg/gojenkins/request.go
@@ -270,6 +270,7 @@ func (r *Requester) DoPostForm(ar *APIRequest, responseStruct interface{}, form 
 	if r.BasicAuth != nil {
 		req.SetBasicAuth(r.BasicAuth.Username, r.BasicAuth.Password)
 	}
+	req.Close = true
 	req.Header.Add("Accept", "*")
 	for k := range ar.Headers {
 		req.Header.Add(k, ar.Headers.Get(k))


### PR DESCRIPTION
During the test, it was found that a http request EOF error occurred when the number of concurrency was large and the request to Jenkins was exceeded.
Solve this problem by limiting the number of concurrent clients